### PR TITLE
refactor: 훅 분리 및 IntersectionObserver 추상화 개선

### DIFF
--- a/app/(home)/CategoryList.tsx
+++ b/app/(home)/CategoryList.tsx
@@ -6,9 +6,10 @@ import { memo } from 'react';
 import { getCategoryColor } from '@/assets/constants';
 
 import { categoriesAtom, selectedCategoryAtom } from './atoms';
-import { useCategorySelect } from './hooks';
+import { useCategorySelect, useSyncCategoryFromUrl } from './hooks';
 
 const CategoryList = () => {
+  useSyncCategoryFromUrl(); // URL 쿼리 → atom 상태 동기화
   const categories = useAtomValue(categoriesAtom);
   const selectedCategory = useAtomValue(selectedCategoryAtom);
   const { handleClickCategory } = useCategorySelect();

--- a/app/(home)/Post.tsx
+++ b/app/(home)/Post.tsx
@@ -6,16 +6,16 @@ import { memo, useState } from 'react';
 import { siteConfig } from 'site.config';
 
 import { DEFAULT_BLUR_BASE64, getCategoryColor } from '@/assets/constants';
-import { PostMeta as Item } from '@/interfaces';
+import type { PostMeta } from '@/interfaces';
 
 import { useTiltEffect } from './hooks';
 
-interface Props {
-  item: Item;
+interface PostProps {
+  item: PostMeta;
 }
 
-const Post = ({ item }: Props) => {
-  const [onError, setOnError] = useState<boolean>(false);
+const Post = ({ item }: PostProps) => {
+  const [hasImageLoadError, setHasImageLoadError] = useState(false);
   const { cover, description, published, category, title, slug, blurImage } = item;
   const { handleMouseMove, handleMouseLeave } = useTiltEffect();
 
@@ -38,7 +38,7 @@ const Post = ({ item }: Props) => {
           onMouseMove={handleMouseMove}
           onMouseLeave={handleMouseLeave}
         >
-          {!onError ? (
+          {!hasImageLoadError ? (
             <Image
               className="
                 object-cover transition-transform
@@ -49,7 +49,7 @@ const Post = ({ item }: Props) => {
               fill
               placeholder="blur"
               blurDataURL={blurImage || DEFAULT_BLUR_BASE64}
-              onError={() => setOnError(true)}
+              onError={() => setHasImageLoadError(true)}
             />
           ) : (
             <div className="flex h-full items-center justify-center">

--- a/app/(home)/PostList.tsx
+++ b/app/(home)/PostList.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React, { memo } from 'react';
+import { memo } from 'react';
 
 import { useInfiniteScrollPostList } from './hooks';
 import Post from './Post';
 
 const PostList = () => {
-  const { pagedPosts, entries } = useInfiniteScrollPostList();
+  const { pagedPosts, sentinelRef } = useInfiniteScrollPostList();
 
   return (
     <>
@@ -26,11 +26,7 @@ const PostList = () => {
           ))}
         </ul>
       </section>
-      <div
-        ref={($elem) => {
-          entries.current[0] = $elem as HTMLDivElement;
-        }}
-      />
+      <div ref={sentinelRef} />
     </>
   );
 };

--- a/app/(home)/hooks/index.ts
+++ b/app/(home)/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useCategorySelect } from './useCategorySelect';
 export { default as useInfiniteScrollPostList } from './useInfiniteScrollPostList';
+export { default as useSyncCategoryFromUrl } from './useSyncCategoryFromUrl';
 export { default as useTiltEffect } from './useTiltEffect';

--- a/app/(home)/hooks/useCategorySelect.ts
+++ b/app/(home)/hooks/useCategorySelect.ts
@@ -1,41 +1,45 @@
-import { useAtom, useSetAtom } from 'jotai';
+'use client';
+
+import { useAtomValue, useSetAtom } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { INITIAL_CATEGORY } from '@/assets/constants';
 
 import { postPageResettableAtom, selectedCategoryAtom } from '../atoms';
 
+/**
+ * 카테고리 클릭 핸들러를 제공합니다.
+ * URL 쿼리를 업데이트하고 포스트 페이지를 리셋합니다.
+ *
+ * 참고: URL → atom 동기화는 useSyncCategoryFromUrl에서 처리합니다.
+ */
 const useCategorySelect = () => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [selectedCategory, setSelectedCategory] = useAtom(selectedCategoryAtom);
+  const selectedCategory = useAtomValue(selectedCategoryAtom);
   const setPostPage = useSetAtom(postPageResettableAtom);
 
   const handleClickCategory = useCallback(
     (target: string) => () => {
       if (selectedCategory === target) return;
+
       const currentQuery = new URLSearchParams(Array.from(searchParams.entries()));
+
       if (target === INITIAL_CATEGORY) {
         currentQuery.delete('category');
       } else {
         currentQuery.set('category', target);
       }
+
       const queryString = currentQuery.toString();
       router.replace(`${pathname}${queryString ? `?${queryString}` : ''}`);
       setPostPage(RESET);
     },
     [router, pathname, searchParams, selectedCategory, setPostPage],
   );
-
-  useEffect(() => {
-    // searchParams가 null이면 아직 초기 렌더링 중이거나 사용할 수 없는 상태
-    if (searchParams === null) return;
-    const categoryFromQuery = searchParams.get('category');
-    setSelectedCategory(categoryFromQuery || INITIAL_CATEGORY);
-  }, [searchParams, setSelectedCategory]);
 
   return { handleClickCategory };
 };

--- a/app/(home)/hooks/useInfiniteScrollPostList.ts
+++ b/app/(home)/hooks/useInfiniteScrollPostList.ts
@@ -9,7 +9,7 @@ const useInfiniteScrollPostList = () => {
   const postsFilterByCategory = useAtomValue(postsFilterByCategoryAtom);
   const [postPage, setPostPage] = useAtom(postPageResettableAtom);
 
-  const { entries, pagedData } = useInfiniteScroll({
+  const { sentinelRef, pagedData } = useInfiniteScroll({
     data: postsFilterByCategory,
     page: postPage,
     intersectCb: useCallback(() => {
@@ -18,7 +18,7 @@ const useInfiniteScrollPostList = () => {
   });
 
   return {
-    entries,
+    sentinelRef,
     pagedPosts: pagedData,
   };
 };

--- a/app/(home)/hooks/useSyncCategoryFromUrl.ts
+++ b/app/(home)/hooks/useSyncCategoryFromUrl.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useSetAtom } from 'jotai';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { INITIAL_CATEGORY } from '@/assets/constants';
+
+import { selectedCategoryAtom } from '../atoms';
+
+/**
+ * URL 쿼리 파라미터의 category 값을 atom 상태와 동기화합니다.
+ *
+ * URL을 Single Source of Truth로 사용하며,
+ * category 쿼리 파라미터가 변경되면 selectedCategoryAtom을 업데이트합니다.
+ */
+const useSyncCategoryFromUrl = () => {
+  const searchParams = useSearchParams();
+  const setSelectedCategory = useSetAtom(selectedCategoryAtom);
+
+  useEffect(() => {
+    if (searchParams === null) return;
+    const categoryFromQuery = searchParams.get('category');
+    setSelectedCategory(categoryFromQuery || INITIAL_CATEGORY);
+  }, [searchParams, setSelectedCategory]);
+};
+
+export default useSyncCategoryFromUrl;

--- a/app/posts/[slug]/utils.ts
+++ b/app/posts/[slug]/utils.ts
@@ -1,0 +1,32 @@
+import { siteConfig } from 'site.config';
+
+export interface PostSEOData {
+  title: string;
+  description: string;
+  keywords: string;
+  coverUrl: string;
+}
+
+interface NotionPageProperties {
+  Name?: string;
+  Desc?: string;
+  Category?: { name?: string };
+  coverUrl?: string;
+}
+
+/**
+ * Notion 페이지 속성에서 SEO 메타데이터를 추출합니다.
+ */
+export const extractPostMetadata = (
+  properties: unknown,
+  defaultTitle: string = 'Post',
+): PostSEOData => {
+  const props = properties as NotionPageProperties | null;
+
+  return {
+    title: props?.Name || defaultTitle,
+    description: props?.Desc || siteConfig.seoDefaultDesc,
+    keywords: props?.Category?.name || '',
+    coverUrl: props?.coverUrl || '',
+  };
+};

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { useIntersectionObserver } from '@/hooks';
 
-interface Props<T> {
+interface UseInfiniteScrollProps<T> {
   data: T[];
   page: number;
   pageSize?: number;
@@ -11,9 +11,31 @@ interface Props<T> {
   threshold?: number[] | number;
 }
 
+interface UseInfiniteScrollReturn<T> {
+  sentinelRef: (node: HTMLElement | null) => void;
+  pagedData: T[];
+}
+
 const INITIAL_PAGE = 0;
 const DEFAULT_PAGE_SIZE = 8;
 
+/**
+ * 무한 스크롤을 위한 페이지네이션 및 IntersectionObserver를 제공합니다.
+ *
+ * @example
+ * const { sentinelRef, pagedData } = useInfiniteScroll({
+ *   data: posts,
+ *   page: currentPage,
+ *   intersectCb: () => setCurrentPage(prev => prev + 1),
+ * });
+ *
+ * return (
+ *   <>
+ *     {pagedData.map(item => <Item key={item.id} />)}
+ *     <div ref={sentinelRef} />
+ *   </>
+ * );
+ */
 const useInfiniteScroll = <T>({
   data,
   page,
@@ -21,13 +43,13 @@ const useInfiniteScroll = <T>({
   intersectCb,
   rootMargin,
   threshold,
-}: Props<T>) => {
+}: UseInfiniteScrollProps<T>): UseInfiniteScrollReturn<T> => {
   const pagedData = useMemo(
     () => data.slice(INITIAL_PAGE, (page + 1) * pageSize),
     [page, pageSize, data],
   );
 
-  const entries = useIntersectionObserver({
+  const { sentinelRef } = useIntersectionObserver({
     rootMargin,
     threshold,
     onIntersect: (entries) => {
@@ -39,7 +61,7 @@ const useInfiniteScroll = <T>({
   });
 
   return {
-    entries,
+    sentinelRef,
     pagedData,
   };
 };

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
-interface IntersectionObserverProps {
+interface UseIntersectionObserverProps {
   root?: null | HTMLElement;
   rootMargin?: string;
   threshold?: number[] | number;
@@ -8,41 +8,72 @@ interface IntersectionObserverProps {
   isLoading?: boolean;
 }
 
+interface UseIntersectionObserverReturn {
+  sentinelRef: (node: HTMLElement | null) => void;
+}
+
+/**
+ * IntersectionObserver를 사용하여 요소의 가시성을 감지합니다.
+ *
+ * @param onIntersect - 요소가 뷰포트에 들어올 때 호출되는 콜백
+ * @param threshold - 콜백을 트리거할 가시성 임계값 (0-1)
+ * @param rootMargin - root 요소의 마진
+ * @param isLoading - 로딩 중일 때 observer를 일시 중지
+ *
+ * @returns sentinelRef - 관찰할 요소에 연결할 ref 콜백
+ *
+ * @example
+ * const { sentinelRef } = useIntersectionObserver({
+ *   onIntersect: (entries) => {
+ *     if (entries[0].isIntersecting) loadMore();
+ *   },
+ * });
+ *
+ * return <div ref={sentinelRef} />;
+ */
 const useIntersectionObserver = ({
   root = null,
   onIntersect,
   threshold = [0.8],
   rootMargin = '0px 0px',
   isLoading = false,
-}: IntersectionObserverProps) => {
-  const entries = useRef<HTMLDivElement[]>([]);
+}: UseIntersectionObserverProps): UseIntersectionObserverReturn => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const elementRef = useRef<HTMLElement | null>(null);
   const onIntersectRef = useRef(onIntersect);
 
-  // 콜백 ref를 최신 상태로 유지 (effect 재실행 없이)
   useEffect(() => {
     onIntersectRef.current = onIntersect;
   }, [onIntersect]);
 
   useEffect(() => {
-    if (!entries.current.length || isLoading) {
-      return undefined;
-    }
+    if (isLoading || !elementRef.current) return;
 
-    const observer = new IntersectionObserver(
+    observerRef.current = new IntersectionObserver(
       (entries, observer) => onIntersectRef.current(entries, observer),
       { root, rootMargin, threshold },
     );
 
-    entries.current.forEach((target) => {
-      if (target) observer.observe(target);
-    });
+    observerRef.current.observe(elementRef.current);
 
     return () => {
-      observer.disconnect();
+      observerRef.current?.disconnect();
     };
   }, [root, rootMargin, threshold, isLoading]);
 
-  return entries;
+  const sentinelRef = useCallback((node: HTMLElement | null) => {
+    if (elementRef.current && observerRef.current) {
+      observerRef.current.unobserve(elementRef.current);
+    }
+
+    elementRef.current = node;
+
+    if (node && observerRef.current) {
+      observerRef.current.observe(node);
+    }
+  }, []);
+
+  return { sentinelRef };
 };
 
 export default useIntersectionObserver;


### PR DESCRIPTION
## 변경 사항

코드 리뷰 피드백을 반영하여 훅 분리 및 추상화를 개선했습니다.

### 훅 리팩토링
- **useSyncCategoryFromUrl**: URL → atom 동기화 사이드 이펙트를 별도 훅으로 분리
- **useCategorySelect**: 클릭 핸들러만 담당하도록 단일 책임 원칙 적용
- **useIntersectionObserver**: entries ref 배열 대신 sentinelRef 콜백 패턴으로 추상화 개선

### 유틸리티 추출
- **extractPostMetadata**: Notion 페이지 속성에서 SEO 메타데이터 추출 로직 통합
- **fetchPostData**: PostPage에서 데이터 fetching 로직 분리

### 네이밍 개선
- `Props` → `PostProps` (컴포넌트별 명확한 네이밍)
- `onError` → `hasImageLoadError` (상태 의미 명확화)
- `PostMeta as Item` → `type { PostMeta }` (타입 import 정리)

## 변경된 파일

| 파일 | 변경 내용 |
|------|----------|
| `app/(home)/hooks/useSyncCategoryFromUrl.ts` | 신규 - URL 동기화 훅 |
| `app/(home)/hooks/useCategorySelect.ts` | useEffect 제거, 클릭 핸들러만 담당 |
| `app/posts/[slug]/utils.ts` | 신규 - 메타데이터 추출 유틸리티 |
| `app/posts/[slug]/page.tsx` | fetchPostData 분리 + extractPostMetadata 사용 |
| `src/hooks/useIntersectionObserver.ts` | sentinelRef 콜백 패턴 적용 |
| `src/hooks/useInfiniteScroll.ts` | 새 인터페이스 적용 + JSDoc 추가 |
| `app/(home)/Post.tsx` | 네이밍 개선 |

## 테스트

- [x] `pnpm build` 성공
- [x] 무한 스크롤 동작 확인
- [x] 카테고리 필터링 동작 확인