### PR TITLE
refactor: React Compiler 적용으로 수동 메모이제이션 제거

### DIFF
--- a/app/(home)/_components/CategoryList.tsx
+++ b/app/(home)/_components/CategoryList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useAtomValue } from 'jotai';
-import { memo, useCallback } from 'react';
 
 import type { Category } from '@/interfaces';
 
@@ -15,13 +14,13 @@ interface CategoryButtonProps {
   onSelect: (name: string) => void;
 }
 
-const CategoryButton = memo(({ category, isSelected, onSelect }: CategoryButtonProps) => {
+const CategoryButton = ({ category, isSelected, onSelect }: CategoryButtonProps) => {
   const { name, color, count } = category;
   const borderColor = isSelected ? getCategoryColor(color) : 'transparent';
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     onSelect(name);
-  }, [onSelect, name]);
+  };
 
   return (
     <li>
@@ -39,9 +38,7 @@ const CategoryButton = memo(({ category, isSelected, onSelect }: CategoryButtonP
       </button>
     </li>
   );
-});
-
-CategoryButton.displayName = 'CategoryButton';
+};
 
 const CategoryList = () => {
   const { handleClickCategory } = useCategoryQueryParam();
@@ -72,4 +69,4 @@ const CategoryList = () => {
   );
 };
 
-export default memo(CategoryList);
+export default CategoryList;

--- a/app/(home)/_components/Post.tsx
+++ b/app/(home)/_components/Post.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { memo, useState } from 'react';
+import { useState } from 'react';
 import { siteConfig } from 'site.config';
 
 import type { PostMeta } from '@/interfaces';
@@ -79,4 +79,4 @@ const Post = ({ post }: PostProps) => {
   );
 };
 
-export default memo(Post);
+export default Post;

--- a/app/(home)/_components/PostList.tsx
+++ b/app/(home)/_components/PostList.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { memo } from 'react';
-
 import { useInfiniteScrollPostList } from '../_hooks';
 import Post from './Post';
 
@@ -31,4 +29,4 @@ const PostList = () => {
   );
 };
 
-export default memo(PostList);
+export default PostList;

--- a/app/(home)/_hooks/useCategoryQueryParam.ts
+++ b/app/(home)/_hooks/useCategoryQueryParam.ts
@@ -3,7 +3,7 @@
 import { useSetAtom, useStore } from 'jotai';
 import { RESET } from 'jotai/utils';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { postPageResettableAtom, selectedCategoryAtom } from '../_atoms';
 import { INITIAL_CATEGORY } from '../_constants';
@@ -33,25 +33,22 @@ const useCategoryQueryParam = () => {
   }, [searchParams, setSelectedCategory]);
 
   // Atom → URL 업데이트 (store.get으로 명령형 읽기하여 불필요한 구독 방지)
-  const handleClickCategory = useCallback(
-    (target: string) => {
-      const currentCategory = store.get(selectedCategoryAtom);
-      if (currentCategory === target) return;
+  const handleClickCategory = (target: string) => {
+    const currentCategory = store.get(selectedCategoryAtom);
+    if (currentCategory === target) return;
 
-      const currentQuery = new URLSearchParams(Array.from(searchParams.entries()));
+    const currentQuery = new URLSearchParams(Array.from(searchParams.entries()));
 
-      if (target === INITIAL_CATEGORY) {
-        currentQuery.delete('category');
-      } else {
-        currentQuery.set('category', target);
-      }
+    if (target === INITIAL_CATEGORY) {
+      currentQuery.delete('category');
+    } else {
+      currentQuery.set('category', target);
+    }
 
-      const queryString = currentQuery.toString();
-      router.replace(`${pathname}${queryString ? `?${queryString}` : ''}`);
-      setPostPage(RESET);
-    },
-    [store, router, pathname, searchParams, setPostPage],
-  );
+    const queryString = currentQuery.toString();
+    router.replace(`${pathname}${queryString ? `?${queryString}` : ''}`);
+    setPostPage(RESET);
+  };
 
   return { handleClickCategory };
 };

--- a/app/(home)/_hooks/useInfiniteScroll.ts
+++ b/app/(home)/_hooks/useInfiniteScroll.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { DEFAULT_PAGE_SIZE, INITIAL_PAGE } from '../_constants';
 import useIntersectionObserver from './useIntersectionObserver';
 
@@ -42,10 +40,7 @@ const useInfiniteScroll = <T>({
   rootMargin,
   threshold,
 }: UseInfiniteScrollProps<T>): UseInfiniteScrollReturn<T> => {
-  const pagedData = useMemo(
-    () => data.slice(INITIAL_PAGE, (page + 1) * pageSize),
-    [page, pageSize, data],
-  );
+  const pagedData = data.slice(INITIAL_PAGE, (page + 1) * pageSize);
 
   const { sentinelRef } = useIntersectionObserver({
     rootMargin,

--- a/app/(home)/_hooks/useInfiniteScrollPostList.ts
+++ b/app/(home)/_hooks/useInfiniteScrollPostList.ts
@@ -1,5 +1,4 @@
 import { useAtom, useAtomValue } from 'jotai';
-import { useCallback } from 'react';
 
 import { postPageResettableAtom, postsFilterByCategoryAtom } from '../_atoms';
 import useInfiniteScroll from './useInfiniteScroll';
@@ -11,9 +10,9 @@ const useInfiniteScrollPostList = () => {
   const { sentinelRef, pagedData } = useInfiniteScroll({
     data: postsFilterByCategory,
     page: postPage,
-    intersectCb: useCallback(() => {
+    intersectCb: () => {
       setPostPage((prev) => prev + 1);
-    }, [setPostPage]),
+    },
   });
 
   return {

--- a/app/(home)/_hooks/useIntersectionObserver.ts
+++ b/app/(home)/_hooks/useIntersectionObserver.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 const DEFAULT_THRESHOLD: number[] = [0.8];
 
@@ -63,7 +63,7 @@ const useIntersectionObserver = ({
     };
   }, [root, rootMargin, threshold, isLoading]);
 
-  const sentinelRef = useCallback((node: HTMLElement | null) => {
+  const sentinelRef = (node: HTMLElement | null) => {
     if (elementRef.current && observerRef.current) {
       observerRef.current.unobserve(elementRef.current);
     }
@@ -73,7 +73,7 @@ const useIntersectionObserver = ({
     if (node && observerRef.current) {
       observerRef.current.observe(node);
     }
-  }, []);
+  };
 
   return { sentinelRef };
 };

--- a/app/(home)/_hooks/useTiltEffect.ts
+++ b/app/(home)/_hooks/useTiltEffect.ts
@@ -1,7 +1,5 @@
 'use client';
 
-import { useCallback } from 'react';
-
 /** 최대 틸트 각도 (degrees) */
 const MAX_TILT_ANGLE = 3;
 
@@ -25,16 +23,16 @@ const calculateTiltAngle = (mousePosition: number, containerSize: number): numbe
  * 3D 틸트 효과를 위한 마우스 이벤트 핸들러를 반환합니다.
  */
 const useTiltEffect = () => {
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.currentTarget;
     const rotateY = calculateTiltAngle(e.nativeEvent.offsetX, target.offsetWidth);
     const rotateX = -calculateTiltAngle(e.nativeEvent.offsetY, target.offsetHeight);
     target.style.transform = `perspective(${CARD_PERSPECTIVE}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
-  }, []);
+  };
 
-  const handleMouseLeave = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+  const handleMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
     e.currentTarget.style.transform = `perspective(${CARD_PERSPECTIVE}px) rotateX(0deg) rotateY(0deg)`;
-  }, []);
+  };
 
   return { handleMouseMove, handleMouseLeave };
 };


### PR DESCRIPTION
## 변경 사항
- React Compiler가 자동 최적화를 수행하므로 수동 메모이제이션 제거
- `memo`, `useMemo`, `useCallback` 제거

## 변경된 파일
- `CategoryList.tsx` - memo, useCallback 제거
- `Post.tsx` - memo 제거
- `PostList.tsx` - memo 제거
- `useCategoryQueryParam.ts` - useCallback 제거
- `useInfiniteScroll.ts` - useMemo 제거
- `useInfiniteScrollPostList.ts` - useCallback 제거
- `useIntersectionObserver.ts` - useCallback 제거
- `useTiltEffect.ts` - useCallback 제거

## 테스트
- [x] TypeScript 컴파일 통과
- [x] ESLint (react-compiler 플러그인) 통과