### PR TITLE
refactor: HEX 색상을 Tailwind 클래스 매핑으로 전환

### DIFF
--- a/app/(home)/_components/CategoryListClient.tsx
+++ b/app/(home)/_components/CategoryListClient.tsx
@@ -5,7 +5,7 @@ import { useAtomValue } from 'jotai';
 import type { Category } from '@/interfaces';
 
 import { selectedCategoryAtom } from '../_atoms';
-import { getCategoryColor } from '../_constants';
+import { getCategoryBorderClass } from '../_constants';
 import { useCategoryQueryParam } from '../_hooks';
 
 interface CategoryButtonProps {
@@ -23,7 +23,7 @@ const categoryButtonClassName = [
 
 const CategoryButton = ({ category, isSelected, onSelect }: CategoryButtonProps) => {
   const { name, color, count } = category;
-  const borderColor = isSelected ? getCategoryColor(color) : 'transparent';
+  const borderColorClass = isSelected ? getCategoryBorderClass(color) : 'border-transparent';
 
   const handleClick = () => {
     onSelect(name);
@@ -33,9 +33,11 @@ const CategoryButton = ({ category, isSelected, onSelect }: CategoryButtonProps)
     <li>
       <button
         type="button"
-        className={categoryButtonClassName}
+        className={`
+          ${categoryButtonClassName}
+          ${borderColorClass}
+        `}
         onClick={handleClick}
-        style={{ borderColor }}
         aria-pressed={isSelected}
       >
         {`${name} (${count})`}

--- a/app/(home)/_components/Post.tsx
+++ b/app/(home)/_components/Post.tsx
@@ -7,7 +7,7 @@ import { siteConfig } from 'site.config';
 
 import type { PostMeta } from '@/interfaces';
 
-import { DEFAULT_BLUR_BASE64, getCategoryColor } from '../_constants';
+import { DEFAULT_BLUR_BASE64, getCategoryBgClass } from '../_constants';
 import { useTiltEffect } from '../_hooks';
 
 interface PostProps {
@@ -75,8 +75,10 @@ const Post = ({ post }: PostProps) => {
           <div className="h-2" />
           <div className="flex items-center gap-2">
             <span
-              className="rounded-sm px-2 py-px text-[12px] text-gray-800"
-              style={{ backgroundColor: getCategoryColor(category?.color) }}
+              className={`
+                rounded-sm px-2 py-px text-[12px] text-gray-800
+                ${getCategoryBgClass(category?.color)}
+              `}
             >
               {category.name}
             </span>

--- a/app/(home)/_constants.ts
+++ b/app/(home)/_constants.ts
@@ -1,22 +1,40 @@
-/** Notion 카테고리 색상을 HEX 코드로 매핑 */
-const COLOR_TABLE = {
-  purple: '#e9d5ff',
-  yellow: '#fef08a',
-  green: '#bbf7d0',
-  blue: '#bfdbfe',
-  pink: '#fbcfe8',
-  brown: '#e7e5e4',
-  red: '#fecaca',
-  orange: '#fed7aa',
-  gray: '#e5e7eb',
-  default: '#cbd5e1',
+/** Notion 카테고리 색상을 Tailwind 배경색 클래스로 매핑 */
+const BG_COLORS = {
+  purple: 'bg-purple-200',
+  yellow: 'bg-yellow-200',
+  green: 'bg-green-200',
+  blue: 'bg-blue-200',
+  pink: 'bg-pink-200',
+  brown: 'bg-stone-200',
+  red: 'bg-red-200',
+  orange: 'bg-orange-200',
+  gray: 'bg-gray-200',
+  default: 'bg-slate-200',
 } as const;
 
-type CategoryColor = keyof typeof COLOR_TABLE;
+/** Notion 카테고리 색상을 Tailwind 테두리색 클래스로 매핑 */
+const BORDER_COLORS = {
+  purple: 'border-purple-200',
+  yellow: 'border-yellow-200',
+  green: 'border-green-200',
+  blue: 'border-blue-200',
+  pink: 'border-pink-200',
+  brown: 'border-stone-200',
+  red: 'border-red-200',
+  orange: 'border-orange-200',
+  gray: 'border-gray-200',
+  default: 'border-slate-200',
+} as const;
 
-/** Notion 카테고리 색상 이름을 HEX 코드로 변환합니다 */
-export const getCategoryColor = (color: string | undefined): string =>
-  COLOR_TABLE[color as CategoryColor] ?? COLOR_TABLE.default;
+type CategoryColor = keyof typeof BG_COLORS;
+
+/** Notion 카테고리 색상 이름을 Tailwind 배경색 클래스로 변환합니다 */
+export const getCategoryBgClass = (color: string | undefined): string =>
+  BG_COLORS[color as CategoryColor] ?? BG_COLORS.default;
+
+/** Notion 카테고리 색상 이름을 Tailwind 테두리색 클래스로 변환합니다 */
+export const getCategoryBorderClass = (color: string | undefined): string =>
+  BORDER_COLORS[color as CategoryColor] ?? BORDER_COLORS.default;
 
 /** 카테고리 필터 초기값 ('All' = 전체 보기) */
 export const INITIAL_CATEGORY = 'All';


### PR DESCRIPTION
## Summary
- COLOR_TABLE을 BG_COLORS, BORDER_COLORS 두 개의 Tailwind 클래스 매핑 테이블로 분리
- inline style 대신 className 사용으로 Tailwind 디자인 시스템과 통합
- getCategoryBgClass, getCategoryBorderClass 함수 제공

## 변경 파일
- `app/(home)/_constants.ts`: 색상 테이블 및 헬퍼 함수
- `app/(home)/_components/Post.tsx`: 카테고리 배지 배경색
- `app/(home)/_components/CategoryListClient.tsx`: 선택된 카테고리 테두리색

## Test plan
- [ ] 홈페이지에서 카테고리 배지 색상 확인
- [ ] 카테고리 필터 선택 시 테두리 색상 확인

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)