### PR TITLE
chore: notion-to-utils 2.1.0 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jotai": "^2.16.2",
     "next": "^16.1.1",
     "notion-to-jsx": "^2.0.0",
-    "notion-to-utils": "^2.0.0",
+    "notion-to-utils": "^2.1.0",
     "p-map": "^7.0.3",
     "plaiceholder": "^3.0.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-utils:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       p-map:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1965,8 +1965,8 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  notion-to-utils@2.0.0:
-    resolution: {integrity: sha512-2jEGz3yLWAL60sVoVm7VMJVQ7Cz9U2sJKzzwurEU+aoxEeT7bEpq7m44lYYXqiCkzSyJTo+XaEwN0QGCbLBn2A==}
+  notion-to-utils@2.1.0:
+    resolution: {integrity: sha512-reXIW8Zisez/9Pk71PxrMPBgrktpSwvuXEt7IjQImieqK4ZmU8puIQwGTIWdZExp+hodl+tDl4nVr4ebs4IViA==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -4554,7 +4554,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  notion-to-utils@2.0.0:
+  notion-to-utils@2.1.0:
     dependencies:
       '@notionhq/client': 5.7.0
       open-graph-scraper: 6.11.0


### PR DESCRIPTION
## 변경 사항

- notion-to-utils 패키지 버전 업데이트 (^2.0.0 → ^2.1.0)

## 변경된 파일

- `package.json` - 의존성 버전 수정
- `pnpm-lock.yaml` - lockfile 갱신