### PR TITLE
feat: Service Worker 추가 (PWA 설치 프롬프트 활성화)

### DIFF
--- a/app/_components/ServiceWorkerRegister.tsx
+++ b/app/_components/ServiceWorkerRegister.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js');
+    }
+  }, []);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { type ReactNode } from 'react';
 import { siteConfig } from 'site.config';
 
 import SiteLayout from './_components/layout';
+import ServiceWorkerRegister from './_components/ServiceWorkerRegister';
 import JotaiProvider from './_providers/JotaiProvider';
 import ThemeProvider from './_providers/ThemeProvider';
 
@@ -71,6 +72,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body>
+        <ServiceWorkerRegister />
         <JotaiProvider>
           <ThemeProvider>
             <SiteLayout>{children}</SiteLayout>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,12 @@
+// 최소 Service Worker - PWA 설치 프롬프트 활성화용
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', () => {
+  // 네트워크 요청 그대로 통과 (캐싱 없음)
+});


### PR DESCRIPTION
## 변경 사항

- 최소 Service Worker 추가 (`public/sw.js`)
- Service Worker 등록 컴포넌트 추가
- PWA 설치 프롬프트(배너) 활성화

## 배경

#80에서 PWA manifest를 추가했으나, Service Worker 없이는 브라우저가 설치 프롬프트를 표시하지 않음.
최소한의 Service Worker를 추가하여 "앱 설치" 프롬프트가 자동으로 뜨도록 함.

## 변경된 파일

- `public/sw.js` - 최소 Service Worker (캐싱 없음)
- `app/_components/ServiceWorkerRegister.tsx` - SW 등록 컴포넌트
- `app/layout.tsx` - 컴포넌트 추가

## 테스트

- [x] 빌드 성공 확인
- [ ] 프로덕션에서 설치 프롬프트 확인