### PR TITLE
chore: notion-to-jsx 2.1.4 업데이트 및 TOC 기능 적용

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 이 프로젝트의 코딩 컨벤션과 주의사항을 정리한 문서입니다.
 
+## 패키지 매니저
+
+이 프로젝트는 **pnpm**을 사용합니다. npm이나 yarn 대신 pnpm을 사용하세요.
+
 ## React Compiler 사용
 
 이 프로젝트는 **React Compiler**를 사용합니다. React Compiler가 자동으로 메모이제이션을 처리하므로:

--- a/app/posts/[slug]/_components/PostRenderer.tsx
+++ b/app/posts/[slug]/_components/PostRenderer.tsx
@@ -19,6 +19,10 @@ const PostRenderer = ({ blocks, title, cover }: PostRendererProps) => {
       title={title}
       cover={cover}
       isDarkMode={isDarkMode}
+      showToc
+      tocStyle={{
+        scrollOffset: 60,
+      }}
     />
   );
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dayjs": "^1.11.19",
     "jotai": "^2.16.2",
     "next": "^16.1.1",
-    "notion-to-jsx": "^2.0.1",
+    "notion-to-jsx": "^2.1.4",
     "notion-to-utils": "^2.1.1",
     "p-map": "^7.0.3",
     "plaiceholder": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^16.1.1
         version: 16.1.1(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-jsx:
-        specifier: ^2.0.1
-        version: 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.1.4
+        version: 2.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-utils:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1959,8 +1959,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  notion-to-jsx@2.0.1:
-    resolution: {integrity: sha512-zKS3yHb4v2AuYn9Gv+kmO1SlIxIbtJOVXUtVONOtJ+q5iUO0OGi0Jk0DrT9SaQicKdev/x5zviWTiiMmCNJazg==}
+  notion-to-jsx@2.1.4:
+    resolution: {integrity: sha512-4C6YMsnpaScpoZb+aXhtlDjyNWGsak0lmxyPGvqrIl7Az9+N7xrjXiRqT1gzwiJDon6b/hy3Dc7cEbRwx+Fcog==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -4543,7 +4543,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  notion-to-jsx@2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  notion-to-jsx@2.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@vanilla-extract/css': 1.18.0
       '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.18.0)


### PR DESCRIPTION
## 변경 사항

- notion-to-jsx 라이브러리 2.0.1 → 2.1.4 업데이트
- PostRenderer에 TOC(목차) 기능 활성화
- CLAUDE.md에 pnpm 패키지 매니저 사용 안내 추가

## 변경된 파일

- `package.json`, `pnpm-lock.yaml` - 패키지 버전 업데이트
- `app/posts/[slug]/_components/PostRenderer.tsx` - TOC 옵션 추가
- `CLAUDE.md` - 패키지 매니저 섹션 추가