### PR TITLE
chore: notion-to-jsx 2.1.6 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dayjs": "^1.11.19",
     "jotai": "^2.16.2",
     "next": "^16.1.1",
-    "notion-to-jsx": "^2.1.4",
+    "notion-to-jsx": "^2.1.6",
     "notion-to-utils": "^2.1.1",
     "p-map": "^7.0.3",
     "plaiceholder": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^16.1.1
         version: 16.1.1(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-jsx:
-        specifier: ^2.1.4
-        version: 2.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.1.6
+        version: 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-utils:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1959,8 +1959,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  notion-to-jsx@2.1.4:
-    resolution: {integrity: sha512-4C6YMsnpaScpoZb+aXhtlDjyNWGsak0lmxyPGvqrIl7Az9+N7xrjXiRqT1gzwiJDon6b/hy3Dc7cEbRwx+Fcog==}
+  notion-to-jsx@2.1.6:
+    resolution: {integrity: sha512-koNVvbFx2MJeA7YCcoHmealGznauV9472ogzsfW9wY1krgrkWIg1qu18hARdfbnlnFUlLqiS6D+163upJIlGBg==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -4543,7 +4543,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  notion-to-jsx@2.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  notion-to-jsx@2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@vanilla-extract/css': 1.18.0
       '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.18.0)


### PR DESCRIPTION
## 변경 사항

- `notion-to-jsx` 패키지를 `^2.1.4`에서 `^2.1.6`으로 업데이트

## 변경된 파일

- `package.json` — 버전 범위 변경
- `pnpm-lock.yaml` — 잠금 파일 갱신