### PR TITLE
chore: 미사용 타입 제거 및 notion-to-utils 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jotai": "^2.16.2",
     "next": "^16.1.1",
     "notion-to-jsx": "^2.1.6",
-    "notion-to-utils": "^2.1.1",
+    "notion-to-utils": "^2.1.2",
     "p-map": "^7.0.3",
     "plaiceholder": "^3.0.0",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-utils:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.1.2
+        version: 2.1.2
       p-map:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1965,8 +1965,8 @@ packages:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  notion-to-utils@2.1.1:
-    resolution: {integrity: sha512-M/jHARBfRn5GrBQs1m8g60k6uF0adeSYmHVgwHQbPuJzQU8ctw19ENbHM/ZTF5+i97XTPex29iNkcoccjAbcsQ==}
+  notion-to-utils@2.1.2:
+    resolution: {integrity: sha512-qrL+wfQNjf/WW5VPRpkjuvBKU807t+vuHxAwaXhQpIeA8mq0Xt81Q/6lw15FXd3XaVcvLIfQIV3GjgnPOFf43w==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -4554,7 +4554,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  notion-to-utils@2.1.1:
+  notion-to-utils@2.1.2:
     dependencies:
       '@notionhq/client': 5.7.0
       open-graph-scraper: 6.11.0

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,19 +1,16 @@
 /**
  * Notion API 타입 및 블로그 도메인 타입 정의
  */
-import {
-  type GetPageResponse,
-  type MultiSelectPropertyItemObjectResponse,
-  type PageObjectResponse,
-} from 'notion-to-utils';
+import { type GetPageResponse, type PageObjectResponse } from 'notion-to-utils';
 
 export type { GetPageResponse, PageObjectResponse };
 
-/** Notion multi_select 속성의 개별 항목 타입 */
-export type SelectPropertyResponse = MultiSelectPropertyItemObjectResponse['multi_select'][number];
-
-/** Notion select 색상 타입 */
-export type SelectColor = SelectPropertyResponse['color'];
+/** Notion select 속성의 값 타입 */
+export interface SelectPropertyResponse {
+  id: string;
+  name: string;
+  color: string;
+}
 
 /** Notion 페이지의 개별 속성 타입 (discriminated union) */
 export type PageProperties = PageObjectResponse['properties'][string];


### PR DESCRIPTION
## 변경 사항

- 미사용 `SelectColor` 타입 제거
- `notion-to-utils` 패키지 `^2.1.1` → `^2.1.2` 업데이트

## 변경된 파일

- `src/interfaces/index.ts` — `SelectColor` 타입 삭제
- `package.json`, `pnpm-lock.yaml` — 패키지 버전 업데이트