### PR TITLE
chore: cacheLife 커스텀 프로필 적용 및 캐시 주기 최적화

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,7 +12,7 @@ import AboutRenderer from './_components/AboutRenderer';
 async function getAboutPageBlocks() {
   'use cache';
   cacheTag('about');
-  cacheLife('minutes');
+  cacheLife('daysForever');
 
   return notionClient.getPageBlocks(env.notionAboutId);
 }

--- a/app/posts/[slug]/_utils/fetchIdBySlug.ts
+++ b/app/posts/[slug]/_utils/fetchIdBySlug.ts
@@ -5,7 +5,7 @@ import notionClient from '@/utils/notionClient';
 export async function getCachedIdBySlug(slug: string, databaseId: string): Promise<string | null> {
   'use cache';
   cacheTag('post-id', slug);
-  cacheLife('hours');
+  cacheLife('max');
 
   const response = await notionClient.dataSources.query({
     data_source_id: databaseId,

--- a/app/posts/[slug]/_utils/fetchNotionPageProperties.ts
+++ b/app/posts/[slug]/_utils/fetchNotionPageProperties.ts
@@ -5,7 +5,7 @@ import notionClient from '@/utils/notionClient';
 export async function getCachedPageProperties(pageId: string) {
   'use cache';
   cacheTag('page-properties', pageId);
-  cacheLife('hours');
+  cacheLife('weeksForever');
 
   if (!pageId) {
     console.error('fetchPageProperties: pageId is undefined or empty');

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -77,7 +77,7 @@ type FetchPostDataResult =
 async function fetchPostData(slug: string): Promise<FetchPostDataResult> {
   'use cache';
   cacheTag('post', slug);
-  cacheLife('minutes');
+  cacheLife('daysForever');
 
   try {
     const id = await getPostId(slug);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,23 @@ const nextConfig = {
       { protocol: 'https', hostname: 'images.unsplash.com' },
     ],
   },
+  cacheLife: {
+    // hours + expire: never
+    hoursForever: {
+      stale: 300, // 5분
+      revalidate: 3600, // 1시간
+    },
+    // days + expire: never
+    daysForever: {
+      stale: 300, // 5분
+      revalidate: 86400, // 1일
+    },
+    // weeks + expire: never
+    weeksForever: {
+      stale: 300, // 5분
+      revalidate: 604800, // 1주
+    },
+  },
   experimental: {
     optimizePackageImports: ['dayjs'],
     useCache: true,

--- a/src/utils/fetchCategories.ts
+++ b/src/utils/fetchCategories.ts
@@ -15,7 +15,7 @@ import notionClient from '@/utils/notionClient';
 export async function getCachedCategories(): Promise<Category[]> {
   'use cache';
   cacheTag('categories');
-  cacheLife('minutes');
+  cacheLife('hoursForever');
 
   const response = await notionClient.dataSources.query({
     data_source_id: env.notionPostDatabaseId,

--- a/src/utils/fetchNotionPostsMeta.ts
+++ b/src/utils/fetchNotionPostsMeta.ts
@@ -44,14 +44,14 @@ export async function fetchNotionPostsMeta(databaseId: string): Promise<GetPageR
 /**
  * Notion에서 포스트 메타데이터를 가져옵니다. (페이지 컴포넌트용)
  *
- * 'use cache'를 사용하여 분 단위로 캐싱됩니다.
+ * 'use cache'를 사용하여 시간 단위로 캐싱됩니다.
  *
  * @returns 블로그 포스트 메타데이터 배열
  */
 export async function getCachedPostsMeta(): Promise<PostMeta[]> {
   'use cache';
   cacheTag('posts');
-  cacheLife('minutes');
+  cacheLife('hoursForever');
 
   const response = await notionClient.dataSources.query({
     data_source_id: env.notionPostDatabaseId,


### PR DESCRIPTION
## Summary
- `next.config.mjs`에 커스텀 cacheLife 프로필 추가 (`hoursForever`, `daysForever`, `weeksForever`)
  - 각 프로필은 revalidate 주기만 다르고, `expire`를 생략하여 캐시가 절대 evict되지 않도록 설정
- 기존 `cacheLife('minutes')`, `cacheLife('hours')` 사용처를 커스텀 프로필로 교체하여 Vercel CPU 실행시간 절감
  - 매 요청마다 STALE → background revalidation이 발생하던 문제 해결

### 변경 내역
| 파일 | 변경 전 | 변경 후 | 이유 |
|------|---------|---------|------|
| `fetchNotionPostsMeta.ts` | `minutes` | `hoursForever` | 포스트 목록은 시간 단위 갱신이면 충분 |
| `fetchCategories.ts` | `minutes` | `hoursForever` | 카테고리도 시간 단위 갱신이면 충분 |
| `about/page.tsx` | `minutes` | `daysForever` | About 페이지는 일 단위 갱신이면 충분 |
| `posts/[slug]/page.tsx` | `minutes` | `daysForever` | 게시글 본문은 일 단위 갱신이면 충분 |
| `fetchNotionPageProperties.ts` | `hours` | `weeksForever` | 페이지 속성은 거의 변하지 않음 |
| `fetchIdBySlug.ts` | `hours` | `max` | slug→id 매핑은 불변 |

## Test plan
- [ ] `pnpm build` 정상 빌드 확인
- [ ] Vercel Preview 배포 후 캐시 헤더 확인 (STALE 빈도 감소)
- [ ] 각 페이지 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)