### PR TITLE
chore: 포스트 상세 로딩 스피너 추가 및 notion-to-jsx 2.1.11 업데이트

### DIFF
--- a/app/posts/[slug]/loading.tsx
+++ b/app/posts/[slug]/loading.tsx
@@ -1,0 +1,15 @@
+const PostLoading = () => {
+  return (
+    <div className="flex h-[70vh] items-center justify-center">
+      <div
+        className="
+          size-8 animate-spin rounded-full border-4 border-gray-200
+          border-t-gray-800
+          dark:border-gray-700 dark:border-t-gray-200
+        "
+      />
+    </div>
+  );
+};
+
+export default PostLoading;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dayjs": "^1.11.19",
     "jotai": "^2.16.2",
     "next": "^16.1.1",
-    "notion-to-jsx": "^2.1.10",
+    "notion-to-jsx": "^2.1.11",
     "notion-to-utils": "^2.1.2",
     "p-map": "^7.0.3",
     "plaiceholder": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^16.1.1
         version: 16.1.1(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-jsx:
-        specifier: ^2.1.10
-        version: 2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^2.1.11
+        version: 2.1.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       notion-to-utils:
         specifier: ^2.1.2
         version: 2.1.2
@@ -1959,8 +1959,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  notion-to-jsx@2.1.10:
-    resolution: {integrity: sha512-7bn4kZ1sGEK7ODcGBIRGufiKA7+r0k2UcIb53miAHdw5Z1Gpy5WGU0WmDd13JvbdwY4fX9Kc4o0/WqoV3OZX3w==}
+  notion-to-jsx@2.1.11:
+    resolution: {integrity: sha512-GwVxUYZJR0rz34EctfG++AyVOi6zkWrMqMzLCrGBn3VCyJ01ws66y8Rrf1U8o3De2BuPFeGUB0syY9t2pYNKxQ==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -4543,7 +4543,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  notion-to-jsx@2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  notion-to-jsx@2.1.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@vanilla-extract/css': 1.18.0
       '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.18.0)


### PR DESCRIPTION
## 변경 사항
- 포스트 상세 페이지(`posts/[slug]`)에 `loading.tsx` 추가하여 라우트 전환 시 즉시 로딩 스피너 표시
- `notion-to-jsx` 2.1.10 → 2.1.11 업그레이드

## 변경된 파일
- `app/posts/[slug]/loading.tsx` (신규)
- `package.json`
- `pnpm-lock.yaml`