### PR TITLE
chore: SEO 개선 - H1 중복 제거, JSON-LD 추가, sitemap changefreq 차등 적용

### DIFF
--- a/app/_components/layout/Header.tsx
+++ b/app/_components/layout/Header.tsx
@@ -25,9 +25,9 @@ const Header = () => {
             p-3
           "
         >
-          <h1 className="text-[20px] font-medium">
+          <p className="text-[20px] font-medium">
             <Link href={'/'}>{siteConfig.blogName}</Link>
-          </h1>
+          </p>
 
           <ul className="flex items-center gap-2">
             {navLinkList.map(({ name, link }) => (

--- a/app/posts/[slug]/_utils/extractPostMetadata.ts
+++ b/app/posts/[slug]/_utils/extractPostMetadata.ts
@@ -5,12 +5,14 @@ export interface PostSEOData {
   description: string;
   keywords: string;
   coverUrl: string;
+  published: string;
 }
 
 interface NotionPageProperties {
   Name?: string;
   Desc?: string;
   Category?: { name?: string };
+  Date?: { start?: string | null };
   coverUrl?: string;
 }
 
@@ -47,6 +49,7 @@ export const extractPostMetadata = (
       description: siteConfig.seoDefaultDesc,
       keywords: '',
       coverUrl: '',
+      published: '',
     };
   }
 
@@ -55,5 +58,6 @@ export const extractPostMetadata = (
     description: properties.Desc || siteConfig.seoDefaultDesc,
     keywords: properties.Category?.name || '',
     coverUrl: properties.coverUrl || '',
+    published: properties.Date?.start || '',
   };
 };

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -118,8 +118,23 @@ const PostPage = async ({ params }: PostPageProps) => {
 
   const { blocks, seo } = result;
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: seo.title,
+    description: seo.description,
+    author: { '@type': 'Person', name: siteConfig.author },
+    url: `${siteConfig.url}/posts/${slug}`,
+    ...(seo.published && { datePublished: seo.published }),
+    ...(seo.coverUrl && { image: seo.coverUrl }),
+  };
+
   return (
     <article>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <PostRenderer
         blocks={blocks}
         title={seo.title}

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -123,9 +123,9 @@ const PostPage = async ({ params }: PostPageProps) => {
     '@type': 'BlogPosting',
     headline: seo.title,
     description: seo.description,
-    author: { '@type': 'Person', name: siteConfig.author },
+    author: { '@type': 'Person', name: siteConfig.author, url: siteConfig.url },
     url: `${siteConfig.url}/posts/${slug}`,
-    ...(seo.published && { datePublished: seo.published }),
+    ...(seo.published && { datePublished: `${seo.published}T00:00:00+09:00` }),
     ...(seo.coverUrl && { image: seo.coverUrl }),
   };
 

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { type GetPageResponse } from 'notion-to-utils';
 import { siteConfig } from 'site.config';
 
-import { PostMeta } from '@/interfaces';
+import { type PostMeta } from '@/interfaces';
 import { env } from '@/lib/env';
 import { createXmlErrorResponse, createXmlResponse } from '@/utils/createXmlResponse';
 import { fetchNotionPostsMeta } from '@/utils/fetchNotionPostsMeta';
@@ -30,12 +30,14 @@ const getSitemapPostIdentifiers = (
 const generateSitemapXml = (notionPostsResponse: GetPageResponse[]): string => {
   const postIdentifiers = getSitemapPostIdentifiers(notionPostsResponse);
 
+  const now = dayjs();
   const postUrls = postIdentifiers
     .map((identifier) => {
+      const isRecent = now.diff(dayjs(identifier.published), 'day') <= 30;
       return `
     <url>
       <loc>${siteConfig.url}/posts/${encodeURIComponent(identifier.slug)}</loc>
-      <changefreq>daily</changefreq>
+      <changefreq>${isRecent ? 'weekly' : 'monthly'}</changefreq>
       <priority>0.7</priority>
       <lastmod>${identifier.published}</lastmod>
     </url>`;
@@ -46,7 +48,7 @@ const generateSitemapXml = (notionPostsResponse: GetPageResponse[]): string => {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>${siteConfig.url}</loc>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <lastmod>${dayjs().format('YYYY-MM-DD')}</lastmod>
   </url>


### PR DESCRIPTION
## 변경 사항
- Header의 블로그명 `<h1>` → `<p>`로 변경하여 포스트 페이지 H1 중복 제거
- 포스트 페이지에 BlogPosting JSON-LD 구조화 데이터 추가
- sitemap changefreq를 최근 30일 이내 글은 `weekly`, 이후 글은 `monthly`로 차등 적용
- 홈페이지 sitemap changefreq `daily` → `weekly`로 변경

## 변경된 파일
- `app/_components/layout/Header.tsx` - H1 → p 태그 변경
- `app/posts/[slug]/_utils/extractPostMetadata.ts` - published 필드 추가
- `app/posts/[slug]/page.tsx` - JSON-LD script 삽입
- `app/sitemap.xml/route.ts` - changefreq 차등 적용