### PR TITLE
fix: RSS/sitemap을 'use cache' 패턴으로 통합하여 stale 문제 해결

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,15 +1,11 @@
 import RSS from 'rss';
 import { siteConfig } from 'site.config';
 
-import { type GetPageResponse } from '@/interfaces';
-import { env } from '@/lib/env';
+import { type PostMeta } from '@/interfaces';
 import { createXmlErrorResponse, createXmlResponse } from '@/utils/createXmlResponse';
-import { fetchNotionPostsMeta } from '@/utils/fetchNotionPostsMeta';
-import getPostsMeta from '@/utils/getPostsMeta';
+import { getCachedPostsMeta } from '@/utils/fetchNotionPostsMeta';
 
-export const revalidate = 300; // 5 minutes
-
-const generateRssFeed = (notionPostsResponse: GetPageResponse[]) => {
+const generateRssFeed = (postsMeta: PostMeta[]) => {
   const feedOptions = {
     title: `${siteConfig.homeTitle} | ${siteConfig.blogName}`,
     description: siteConfig.seoDefaultDesc,
@@ -20,7 +16,7 @@ const generateRssFeed = (notionPostsResponse: GetPageResponse[]) => {
   };
 
   const feed = new RSS(feedOptions);
-  getPostsMeta(notionPostsResponse).forEach(({ title, description, slug, published }) => {
+  postsMeta.forEach(({ title, description, slug, published }) => {
     feed.item({
       title,
       description,
@@ -34,8 +30,8 @@ const generateRssFeed = (notionPostsResponse: GetPageResponse[]) => {
 
 export async function GET() {
   try {
-    const databaseItems = await fetchNotionPostsMeta(env.notionPostDatabaseId);
-    const rssXml = generateRssFeed(databaseItems);
+    const postsMeta = await getCachedPostsMeta();
+    const rssXml = generateRssFeed(postsMeta);
     return createXmlResponse(rssXml);
   } catch (error) {
     return createXmlErrorResponse('Could not generate RSS feed.', error);

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,22 +1,14 @@
 import dayjs from 'dayjs';
-import { type GetPageResponse } from 'notion-to-utils';
 import { siteConfig } from 'site.config';
 
 import { type PostMeta } from '@/interfaces';
-import { env } from '@/lib/env';
 import { createXmlErrorResponse, createXmlResponse } from '@/utils/createXmlResponse';
-import { fetchNotionPostsMeta } from '@/utils/fetchNotionPostsMeta';
-import getPostsMeta from '@/utils/getPostsMeta';
-
-export const revalidate = 600; // 10 minutes
+import { getCachedPostsMeta } from '@/utils/fetchNotionPostsMeta';
 
 type SitemapPostIdentifier = Pick<PostMeta, 'slug' | 'published'>;
 
-const getSitemapPostIdentifiers = (
-  notionPostsResponse: GetPageResponse[],
-): SitemapPostIdentifier[] => {
-  const posts = getPostsMeta(notionPostsResponse);
-  return posts
+const getSitemapPostIdentifiers = (postsMeta: PostMeta[]): SitemapPostIdentifier[] => {
+  return postsMeta
     .map((post) => {
       const { slug, published } = post;
       const formattedPublished = published ? dayjs(published).format('YYYY-MM-DD') : '';
@@ -27,8 +19,8 @@ const getSitemapPostIdentifiers = (
     );
 };
 
-const generateSitemapXml = (notionPostsResponse: GetPageResponse[]): string => {
-  const postIdentifiers = getSitemapPostIdentifiers(notionPostsResponse);
+const generateSitemapXml = (postsMeta: PostMeta[]): string => {
+  const postIdentifiers = getSitemapPostIdentifiers(postsMeta);
 
   const now = dayjs();
   const postUrls = postIdentifiers
@@ -66,8 +58,8 @@ const generateSitemapXml = (notionPostsResponse: GetPageResponse[]): string => {
 
 export async function GET() {
   try {
-    const databaseItems = await fetchNotionPostsMeta(env.notionPostDatabaseId);
-    const sitemapXml = generateSitemapXml(databaseItems);
+    const postsMeta = await getCachedPostsMeta();
+    const sitemapXml = generateSitemapXml(postsMeta);
     return createXmlResponse(sitemapXml);
   } catch (error) {
     return createXmlErrorResponse('Could not generate sitemap.', error);

--- a/src/utils/fetchNotionPostsMeta.ts
+++ b/src/utils/fetchNotionPostsMeta.ts
@@ -25,24 +25,7 @@ const createPostsQueryOptions = () => {
 };
 
 /**
- * Notion에서 포스트 메타데이터를 가져옵니다. (Route Handler용)
- *
- * 캐싱 없이 직접 호출되며, Route의 revalidate로 캐싱됩니다.
- *
- * @param databaseId - Notion 데이터베이스 ID
- * @returns Notion 페이지 응답 배열
- */
-export async function fetchNotionPostsMeta(databaseId: string): Promise<GetPageResponse[]> {
-  const response = await notionClient.dataSources.query({
-    data_source_id: databaseId,
-    ...createPostsQueryOptions(),
-  } as Parameters<typeof notionClient.dataSources.query>[0]);
-
-  return response.results as GetPageResponse[];
-}
-
-/**
- * Notion에서 포스트 메타데이터를 가져옵니다. (페이지 컴포넌트용)
+ * Notion에서 포스트 메타데이터를 가져옵니다.
  *
  * 'use cache'를 사용하여 시간 단위로 캐싱됩니다.
  *


### PR DESCRIPTION
## 변경 사항

- Next 16의 `cacheComponents` 모델에서 segment-level `revalidate` export가 의도대로 동작하지 않아, RSS/sitemap이 수십 일씩 stale RSS를 내려주던 문제를 해결합니다.
- RSS/sitemap을 페이지와 동일하게 `getCachedPostsMeta` (`'use cache'` + `cacheTag('posts')` + `cacheLife('hoursForever')`) 를 사용하도록 통합합니다.
- 더 이상 사용되지 않는 비캐시 함수 `fetchNotionPostsMeta` 를 제거합니다.

### 동작 변화
| 항목 | as-is | to-be |
|---|---|---|
| RSS revalidate | 5분 (의도) / 실제로는 깨짐 | 1시간 (`hoursForever`) |
| sitemap revalidate | 10분 (의도) / 실제로는 깨짐 | 1시간 (`hoursForever`) |
| 캐시 무효화 범위 | 별도 (자동 무효화 없음) | `posts` 태그로 페이지와 공유 |

> 향후 Notion publish webhook → `revalidateTag('posts')` 엔드포인트를 추가하면 페이지/RSS/sitemap 을 동시에 즉시 무효화 가능한 구조입니다.

## 변경된 파일
- `app/rss.xml/route.ts` — `revalidate=300` 제거, `getCachedPostsMeta` 사용
- `app/sitemap.xml/route.ts` — `revalidate=600` 제거, `getCachedPostsMeta` 사용
- `src/utils/fetchNotionPostsMeta.ts` — 미사용 함수 `fetchNotionPostsMeta` 제거

## 테스트
- [x] `tsc --noEmit` 통과
- [x] 로컬 `http://localhost:3000/rss.xml` 출력이 production RSS와 정규화 후 100% 동일 확인 (dynamic 필드 `pubDate`, `lastBuildDate` 제외)
- [ ] 머지 후 다음 GitHub Actions blog-post-workflow batch에서 README가 최신 글로 갱신되는지 모니터링